### PR TITLE
Use App Store Connect API Key for fastlane auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
           bundle exec fastlane test
 
       - name: Build & Archive
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
         run: |
           bundle exec fastlane beta
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,6 +20,14 @@ platform :ios do
   private_lane :build do |options|
     snapshot if options[:screenshots]
 
+    app_store_connect_api_key(
+      key_id: ENV['APP_STORE_CONNECT_API_KEY_ID'],
+      issuer_id: ENV['APP_STORE_CONNECT_API_KEY_ISSUER_ID'],
+      key_content: ENV['APP_STORE_CONNECT_API_KEY_CONTENT'],
+      is_key_content_base64: true,
+      in_house: false
+    )
+
     cert
     sigh
     gym scheme: 'HockeyPlayoffs'


### PR DESCRIPTION
The beta lane was failing in CI because `cert` tried to do an interactive
Apple ID login. Switch to App Store Connect API Key auth via
`app_store_connect_api_key`, which is picked up automatically by `cert`,
`sigh`, and `deliver`, and pass the key material from GitHub Actions
secrets.

https://claude.ai/code/session_01B5h8C2jS3W5Y1LFTUZ8GtD