### PR TITLE
Fix fastlane match auth failure in CI by passing MATCH_GIT_BASIC_AUTHORIZATION

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
           bundle exec fastlane test
 
       - name: Build & Archive
+        env:
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
         run: |
           bundle exec fastlane beta
 


### PR DESCRIPTION
The match step was failing with "could not read Username for 'https://github.com':
terminal prompts disabled" because no credentials were available when cloning the
certificates repo. Pass the MATCH_GIT_BASIC_AUTHORIZATION secret as an env var so
fastlane match can authenticate over HTTPS without an interactive prompt.

https://claude.ai/code/session_0133xov3de2XFGiaSEUiyLth