### PR TITLE
Fix fastlane match authentication in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Build & Archive
         env:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         run: |
           bundle exec fastlane beta
 


### PR DESCRIPTION
## Summary

- Pass `MATCH_GIT_BASIC_AUTHORIZATION` secret as an env var on the "Build & Archive" step so fastlane match can clone the certificates repo over HTTPS without interactive prompts
- Pass `MATCH_PASSWORD` secret as an env var so fastlane match can decrypt the certificates in non-interactive CI mode

## Required secrets

Add these two secrets to the repository (Settings → Secrets and variables → Actions):

| Secret | Value |
|---|---|
| `MATCH_GIT_BASIC_AUTHORIZATION` | `base64("github-username:personal-access-token")` — PAT needs `repo` scope on `pmairoldi/certificates` |
| `MATCH_PASSWORD` | The passphrase used when the certificates were first stored with `fastlane match` |

## Test plan

- [ ] Add both secrets to the repository
- [ ] Trigger a build and confirm the `match` step clones and decrypts certificates successfully
- [ ] Confirm the full `beta` lane completes without errors

https://claude.ai/code/session_0133xov3de2XFGiaSEUiyLth