### PR TITLE
Include short day of week in game overview date

### DIFF
--- a/HockeyPlayoffs/Handlers/FormatterHandler.m
+++ b/HockeyPlayoffs/Handlers/FormatterHandler.m
@@ -37,7 +37,7 @@
         [_fullDateTimeFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
         
         _longDateFormatter = [[NSDateFormatter alloc] init];
-        [_longDateFormatter setDateFormat:@"MMM d, yyyy"];
+        [_longDateFormatter setDateFormat:@"EEE, MMM d, yyyy"];
         
         _timeFormatter = [[NSDateFormatter alloc] init];
         [_timeFormatter setDateFormat:@"h:mm a"];

--- a/HockeyPlayoffsTests/DateTimeHandlerTests.swift
+++ b/HockeyPlayoffsTests/DateTimeHandlerTests.swift
@@ -70,7 +70,7 @@ class DateTimeHandlerTests: XCTestCase {
     func testDateFromWellFormattedDateAndNilTime() {
         
         let actualResult = DateTimeHandler.getDateForDate("2015-06-22", andTime: nil)
-        let expectedResult = "Jun 22, 2015"
+        let expectedResult = "Mon, Jun 22, 2015"
         
         XCTAssertEqual(actualResult, expectedResult)
     }
@@ -78,7 +78,7 @@ class DateTimeHandlerTests: XCTestCase {
     func testDateFromWellFormattedDateAndEmptyTime() {
         
         let actualResult = DateTimeHandler.getDateForDate("2015-06-22", andTime: "")
-        let expectedResult = "Jun 22, 2015"
+        let expectedResult = "Mon, Jun 22, 2015"
         
         XCTAssertEqual(actualResult, expectedResult)
     }
@@ -86,7 +86,7 @@ class DateTimeHandlerTests: XCTestCase {
     func testDateFromWellFormattedDateAndTime() {
         
         let actualResult = DateTimeHandler.getDateForDate("2015-06-22", andTime: "10:53:00")
-        let expectedResult = "Jun 22, 2015"
+        let expectedResult = "Mon, Jun 22, 2015"
         
         XCTAssertEqual(actualResult, expectedResult)
     }


### PR DESCRIPTION
Update longDateFormatter to prepend the short weekday (e.g. "Mon, Jun 22, 2015")
so the game overview shows the day alongside the date, and update the
DateTimeHandler tests to match.