### PR TITLE
show TBD instead of formatted 9999-12-31 sentinel date

### DIFF
--- a/HockeyPlayoffs/Handlers/DateTimeHandler.m
+++ b/HockeyPlayoffs/Handlers/DateTimeHandler.m
@@ -38,7 +38,7 @@
     }
 
     if ([date isEqualToString:@"9999-12-31"]) {
-        return NSLocalizedString(@"date.tbd", nil);
+        return @"";
     }
 
     NSDate *formattedDate = [[self class] convertToTimeZoneForDate:date andTime:time];

--- a/HockeyPlayoffs/Handlers/DateTimeHandler.m
+++ b/HockeyPlayoffs/Handlers/DateTimeHandler.m
@@ -36,9 +36,13 @@
     if (![StringHandler compareString:date withRegex:@"\\d{4}-\\d{2}-\\d{2}"]) {
         return @"";
     }
-    
+
+    if ([date isEqualToString:@"9999-12-31"]) {
+        return NSLocalizedString(@"date.tbd", nil);
+    }
+
     NSDate *formattedDate = [[self class] convertToTimeZoneForDate:date andTime:time];
-    
+
     NSDateFormatter *formatter = [FormatterHandler longDateFormatter];
     
     return [formatter stringFromDate:formattedDate];

--- a/HockeyPlayoffs/SupportingFiles/en.lproj/Localizable.strings
+++ b/HockeyPlayoffs/SupportingFiles/en.lproj/Localizable.strings
@@ -65,7 +65,6 @@
 
 "final" = "Final";
 "time.tbd" = "TBD";
-"date.tbd" = "TBD";
 
 "recent.yesterday" = "Yesterday";
 "recent.today" = "Today";

--- a/HockeyPlayoffs/SupportingFiles/en.lproj/Localizable.strings
+++ b/HockeyPlayoffs/SupportingFiles/en.lproj/Localizable.strings
@@ -65,6 +65,7 @@
 
 "final" = "Final";
 "time.tbd" = "TBD";
+"date.tbd" = "TBD";
 
 "recent.yesterday" = "Yesterday";
 "recent.today" = "Today";


### PR DESCRIPTION
The backend uses 9999-12-31 to mean "date not yet known" for upcoming
games. Detect that sentinel in DateTimeHandler.getDateForDate:andTime:
and return the new "date.tbd" localized string instead of formatting
"Fri, Dec 31, 9999".

https://claude.ai/code/session_014YEpL8nj4PhG9C3PFMcxSx